### PR TITLE
refactor: Cleanup compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required (VERSION 2.8.0)
 project (ibmdb2i)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -O0")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-brtl,-lc,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/usr/lib,-bbigtoc,-lpthread,-liconv")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-brtl,-lc,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/usr/lib,-bbigtoc,-lpthread,-liconv")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-brtl,-lc,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/usr/lib,-bbigtoc,-lpthread,-liconv")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required (VERSION 2.8.0)
 project (ibmdb2i)
-# Dave add -malign-power -malign-natural (below)
-# Our power engine will run better. Also fewer gcc odd boundary over runs.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -O0")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -malign-power -malign-natural -ggdb -O0")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -malign-power -malign-natural -ggdb -O0")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-brtl,-lc,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/usr/lib,-bbigtoc,-lpthread,-liconv")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-brtl,-lc,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/usr/lib,-bbigtoc,-lpthread,-liconv")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-brtl,-lc,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib:/usr/lib,-bbigtoc,-lpthread,-liconv")
@@ -52,3 +48,6 @@ MYSQL_ADD_PLUGIN(ibmdb2i ${IBMDB2I_SOURCES}
  STORAGE_ENGINE MODULE_ONLY
  LINK_LIBRARIES ${PASELIB_LIBRARIES})
 
+# Dave add -malign-power -malign-natural (below)
+# Our power engine will run better. Also fewer gcc odd boundary over runs.
+target_compile_options(ibmdb2i PRIVATE -malign-power -malign-natural -ggdb -O0)


### PR DESCRIPTION
For now we want to always compile without optimizations because
we found that using `-O2` causes issues selecting data from tables.
Uur mariadb.spec adds `-O2` to CMAKE_CXX_FLAGS_RELWITHDEBINFO
when the build type is RELWITHDEBINFO (which is the default).
This then causes this storage engine to build with -O2
optimizations becuase CMAKE_CXX_FLAGS_RELWITHDEBINFO are
added to the end of CMAKE_CXX_FLAGS.

We can work around this issue by appending -O0 to
CMAKE_CXX_FLAGS_RELWITHDEBINFO which will then cause -O0
to override the -O2 set previously but this pollutes the
global CMAKE_CXX_FLAGS_RELWITHDEBINFO variable and causes everything
to be built unoptimized. Instead we can use target_compile_options
which only pass compile options for this target.

The second commit:

Removes setting CMAKE_C_FLAGS because  this project only contains c++ source files
and we do not want to pollute the global CMAKE_C_FLAGS variable.