### PR TITLE
revert: Add required link libraries (mysys,sql)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set(PASELIB_LIBRARIES
 # -- INSTALL SONAME 'ha_ibmdb2i';
 MYSQL_ADD_PLUGIN(ibmdb2i ${IBMDB2I_SOURCES} 
  STORAGE_ENGINE MODULE_ONLY
- LINK_LIBRARIES ${PASELIB_LIBRARIES} mysys sql)
+ LINK_LIBRARIES ${PASELIB_LIBRARIES})
 
 # Dave add -malign-power -malign-natural (below)
 # Our power engine will run better. Also fewer gcc odd boundary over runs.


### PR DESCRIPTION
Initially, mysys and sql was added to link libraries to resolve undefined
symbols when this storage engine was built with mariadb using cmake
3.16.0. For now we will fallback and build with cmake 3.7.2 which does
not have the undefined symbols issue. Therefore we should revert the change
that added mysys and sql to the link libraries.