### PR TITLE
doc: Fix mysqld path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ version
 
 start
 ```
-/QOpenSys/pkgs/sbin/mysqld & 
+/QOpenSys/pkgs/bin/mysqld & 
 ```
 
 setup


### PR DESCRIPTION
Mariadb in RPM form will ship `mysqld` under `/QOpenSys/pkgs/bin` instead of `/QOpenSys/pkgs/sbin`