### PR TITLE
refactor: Update functions after prototype changes

### DIFF
--- a/db2i_conversion.cc
+++ b/db2i_conversion.cc
@@ -241,7 +241,11 @@ static void get_field_default_value(Field *field,
     defaultClause.append(" DEFAULT ");
     if (!field->is_null())
     {
-      my_bitmap_map *old_map = tmp_use_all_columns(field->table, field->table->read_set);
+      #if MYSQL_VERSION_ID >= 100328
+        MY_BITMAP *old_map = tmp_use_all_columns(field->table, &field->table->read_set);
+      #else
+        my_bitmap_map *old_map = tmp_use_all_columns(field->table, field->table->read_set);
+      #endif
       char tmp[MAX_FIELD_WIDTH];
       
       if (field->real_type() == MYSQL_TYPE_ENUM ||
@@ -373,7 +377,11 @@ static void get_field_default_value(Field *field,
         else
           defaultClause.length(0);
       }
-      tmp_restore_column_map(field->table->read_set, old_map);
+      #if MYSQL_VERSION_ID >= 100328
+        tmp_restore_column_map(&field->table->read_set, old_map);
+      #else
+        tmp_restore_column_map(field->table->read_set, old_map);
+      #endif
     }
     else if (field->maybe_null())
       defaultClause.append(STRING_WITH_LEN("NULL"));


### PR DESCRIPTION
[21809f9a450df1bc44cef36377f96b516ac4a9ae](https://github.com/MariaDB/server/commit/21809f9a450df1bc44cef36377f96b516ac4a9ae) changes the following function prototypes:

* tmp_use_all_columns, dbug_tmp_use_all_columns
  to accept MY_BITMAP** and to return MY_BITMAP * instead of my_bitmap_map*

* tmp_restore_column_map, dbug_tmp_restore_column_maps to accept
  MY_BITMAP* instead of my_bitmap_map*


Fixes #17